### PR TITLE
Restore NPQ domain score extraction and DB insertion

### DIFF
--- a/src/report_refactor/cognitive_importer.py
+++ b/src/report_refactor/cognitive_importer.py
@@ -1,0 +1,48 @@
+import logging
+
+logging.basicConfig(
+    level=logging.INFO, 
+    format='%(asctime)s %(levelname)s %(message)s',
+    handlers=[
+        logging.FileHandler("importer.log", mode='w', encoding='utf-8'),
+        logging.StreamHandler()
+    ]
+)
+logger = logging.getLogger(__name__) 
+logger.info("Logging initialized: starting cognitive_importer.py")
+
+# ... (file truncated for brevity) ...
+    if npq_pages:
+        npq_questions = extract_npq_questions_pymupdf(pdf_path, npq_pages)
+        npq_questions = [
+            {
+                'question_number': t[0],
+                'question_text': t[1],
+                'score': t[2],
+                'severity': t[3],
+                'domain': t[4] if len(t) > 4 else None
+            }
+            for t in npq_questions
+        ]
+        npq_domain_scores = extract_npq_domain_scores_from_pdf(pdf_path, npq_pages)
+        # Convert tuples to dicts for DB insertion
+        npq_domain_scores = [
+            {'domain': t[0], 'score': t[1], 'severity': t[2]}
+            for t in npq_domain_scores
+        ]
+    else:
+        npq_section_text = '\n'.join([lines[i] for i in npq_pages]) if npq_pages else raw_text
+        npq_questions = parse_npq_questions_from_text(npq_section_text)
+        npq_questions = [
+            {
+                'question_number': t[0],
+                'question_text': t[1],
+                'score': t[2],
+                'severity': t[3],
+                'domain': None
+            }
+            for t in npq_questions
+        ]
+    insert_npq_responses(session_id, npq_questions)
+    insert_npq_domain_scores(session_id, npq_domain_scores)
+# ... (file truncated for brevity) ...

--- a/src/report_refactor/parsing_helpers.py
+++ b/src/report_refactor/parsing_helpers.py
@@ -1,0 +1,78 @@
+import logging
+logger = logging.getLogger(__name__)
+logger.info("MODULE FINGERPRINT: parsing_helpers.py loaded from src/report_refactor at 2025-04-23T21:46:28+08:00")
+
+import fitz  # PyMuPDF
+import re
+import os
+import csv
+import pdfplumber
+import logging
+from typing import List, Tuple, Dict, Any, Optional
+
+# Use explicit relative import for DSM logic
+from .asrs_dsm_mapper import RESPONSE_SCORES, LOWER_THRESHOLD_QUESTIONS, is_met, DSM5_ASRS_MAPPING
+
+# Setup logging
+logger = logging.getLogger(__name__)
+# Configure logging further if needed (e.g., level, handler)
+# logging.basicConfig(level=logging.INFO) # Example configuration
+
+# --- Core Extraction Logic ---
+
+# ... (file truncated for brevity) ...
+
+def extract_npq_domain_scores_from_pdf(pdf_path, npq_pages_indices):
+    """
+    Extracts NPQ Domain Scores from tables within a PDF using pdfplumber.
+    Looks for tables containing 'Domain', 'Score', and 'Severity' headers.
+
+    Args:
+        pdf_path (str): Path to the PDF file.
+        npq_pages_indices (List[int]): List of 0-based page indices containing NPQ content.
+
+    Returns:
+        List[Tuple[str, int, str]]: A list of tuples, where each tuple contains:
+                                     (domain_name, score, severity)
+    """
+    import pdfplumber
+    import logging
+    logger = logging.getLogger(__name__)
+    domain_data = []
+    if not npq_pages_indices:
+        logger.warning("No NPQ page indices provided for domain score extraction.")
+        return []
+    try:
+        with pdfplumber.open(pdf_path) as pdf:
+            all_tables = []
+            for page_idx in npq_pages_indices:
+                if page_idx >= len(pdf.pages):
+                    logger.warning(f"Page index {page_idx} out of range for PDF during domain score extraction.")
+                    continue
+                page = pdf.pages[page_idx]
+                tables = page.extract_tables()
+                if tables:
+                    all_tables.extend(tables)
+            for table in all_tables:
+                if table and len(table) > 0:
+                    header_row = table[0]
+                    if header_row and len(header_row) >= 3:
+                        header_cells = [str(cell).strip().lower() if cell else "" for cell in header_row]
+                        if "domain" in header_cells[0] and "score" in header_cells[1]:
+                            for row in table[1:]:
+                                if not row or len(row) < 3 or not row[0]:
+                                    continue
+                                domain = str(row[0]).strip()
+                                score_str = str(row[1]).strip() if row[1] else ""
+                                severity = str(row[2]).strip() if row[2] else ""
+                                if domain.lower() == "domain" or not score_str.isdigit():
+                                    continue
+                                try:
+                                    score = int(score_str)
+                                    domain_data.append((domain, score, severity))
+                                except (ValueError, TypeError):
+                                    continue
+    except Exception as e:
+        logger.error(f"Error extracting NPQ domain scores: {e}")
+        return []
+    return domain_data


### PR DESCRIPTION
This PR restores the NPQ domain score extraction and insertion functionality that was lost during a previous refactor. 

- Adds `extract_npq_domain_scores_from_pdf` to parsing_helpers.py
- Calls this function from cognitive_importer.py
- Converts domain score tuples to dicts to match DB insertion signature
- No other logic affected; orthogonal, minimal change

Fixes issues with missing NPQ domain scores in database after import.