### PR TITLE
Add patient_id to all result tables and propagate from PDF parsing

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -1,4 +1,4 @@
-from sqlalchemy import create_engine, Column, Integer, String, DateTime, Boolean
+from sqlalchemy import create_engine, Column, Integer, String, DateTime, Boolean, Float
 from sqlalchemy.orm import declarative_base, sessionmaker
 import os
 from datetime import datetime
@@ -36,23 +36,310 @@ class Referral(Base):
     report_unprocessed = Column(Boolean, default=True)
     report_processed = Column(Boolean, default=False)
     report_sent_date = Column(DateTime)
+    test_resent = Column(Boolean, default=False)
+    test_resent_time = Column(DateTime, nullable=True)
+    pdf_path = Column(String)
+
+class TestSession(Base):
+    __tablename__ = 'test_sessions'
+    id = Column(Integer, primary_key=True)
+    referral_id = Column(Integer, nullable=True)
+    session_date = Column(DateTime, default=datetime.utcnow)
+    status = Column(String, default='pending')
+
+# --- Cognitive Score Model ---
+class CognitiveScore(Base):
+    __tablename__ = 'cognitive_scores'
+    id = Column(Integer, primary_key=True)
+    session_id = Column(Integer, nullable=False)
+    patient_id = Column(String)  # Unique patient identifier from PDF
+    domain = Column(String, nullable=False)
+    patient_score = Column(String)
+    standard_score = Column(String)
+    percentile = Column(String)
+    validity_index = Column(String)
+
+# --- Subtest Result Model ---
+class SubtestResult(Base):
+    __tablename__ = 'subtest_results'
+    id = Column(Integer, primary_key=True)
+    session_id = Column(Integer, nullable=False)
+    patient_id = Column(String)  # Unique patient identifier from PDF
+    subtest_name = Column(String, nullable=False)
+    metric = Column(String, nullable=False)
+    score = Column(Float)
+    standard_score = Column(Float)
+    percentile = Column(Float)
+    validity_flag = Column(Boolean, default=True)
+
+# --- ASRS Response Model ---
+class ASRSResponse(Base):
+    __tablename__ = 'asrs_responses'
+    id = Column(Integer, primary_key=True)
+    session_id = Column(Integer, nullable=False)
+    patient_id = Column(String)  # Unique patient identifier from PDF
+    question_number = Column(Integer, nullable=False)
+    part = Column(String, nullable=True)
+    response = Column(String, nullable=False)
+
+# --- DSM Diagnosis Model ---
+class DSMDiagnosis(Base):
+    __tablename__ = 'dsm_diagnoses'
+    id = Column(Integer, primary_key=True)
+    session_id = Column(Integer, nullable=False)
+    patient_id = Column(String)  # Unique patient identifier from PDF
+    diagnosis = Column(String, nullable=False)
+    code = Column(String, nullable=True)
+    severity = Column(String, nullable=True)
+    notes = Column(String, nullable=True)
+
+# --- DSM Criteria Met Model ---
+class DSMCriteriaMet(Base):
+    __tablename__ = 'dsm_criteria_met'
+    id = Column(Integer, primary_key=True)
+    session_id = Column(Integer, nullable=False)
+    patient_id = Column(String)  # Unique patient identifier from PDF
+    dsm_criterion = Column(String, nullable=False)
+    dsm_category = Column(String, nullable=False)
+    is_met = Column(Boolean, nullable=False)
+
+# --- Epworth Response Model ---
+class EpworthResponse(Base):
+    __tablename__ = 'epworth_responses'
+    id = Column(Integer, primary_key=True)
+    session_id = Column(Integer, nullable=False)
+    patient_id = Column(String)  # Unique patient identifier from PDF
+    situation = Column(String, nullable=False)
+    score = Column(Integer, nullable=False)
+
+# --- Epworth Summary Model ---
+class EpworthSummary(Base):
+    __tablename__ = 'epworth_summary'
+    id = Column(Integer, primary_key=True)
+    session_id = Column(Integer, nullable=False)
+    patient_id = Column(String)  # Unique patient identifier from PDF
+    total_score = Column(Integer, nullable=False)
+    interpretation = Column(String, nullable=True)
+
+# --- NPQ Domain Score Model ---
+class NPQDomainScore(Base):
+    __tablename__ = 'npq_domain_scores'
+    id = Column(Integer, primary_key=True)
+    session_id = Column(Integer, nullable=False)
+    patient_id = Column(String)  # Unique patient identifier from PDF
+    domain = Column(String, nullable=False)
+    score = Column(Integer, nullable=False)
+    severity = Column(String, nullable=False)
+
+# --- NPQ Response Model ---
+class NPQResponse(Base):
+    __tablename__ = 'npq_responses'
+    id = Column(Integer, primary_key=True)
+    session_id = Column(Integer, nullable=False)
+    patient_id = Column(String)  # Unique patient identifier from PDF
+    domain = Column(String, nullable=False)
+    question_number = Column(Integer, nullable=False)
+    question_text = Column(String, nullable=False)
+    score = Column(Integer, nullable=False)
+    severity = Column(String, nullable=False)
 
 Base.metadata.create_all(engine)
 Session = sessionmaker(bind=engine)
 
+# --- Save Referral ---
 def save_referral(parsed, subject, body, referrer=None, referrer_email=None, referral_received_time=None, referral_confirmed_time=None):
+    """
+    Save a new referral to the database.
+    Returns the referral ID.
+    """
     with Session() as session:
         referral = Referral(
-            email=parsed['email'],
-            mobile=parsed['mobile'],
-            dob=parsed['dob'],
-            id_number=parsed['id_number'],
+            email=parsed.get('email', ''),
+            mobile=parsed.get('mobile', ''),
+            dob=parsed.get('dob', ''),
+            id_number=parsed.get('id_number', ''),
             raw_subject=subject,
             raw_body=body,
             referral_received_time=referral_received_time,
+            referral_confirmed_time=referral_confirmed_time,
             referrer=referrer,
             referrer_email=referrer_email,
-            referral_confirmed_time=referral_confirmed_time
         )
         session.add(referral)
         session.commit()
+        return referral.id
+
+# --- Test Session Creation ---
+def create_test_session(referral_id, session_date, status="pending"):
+    with Session() as session:
+        test_session = TestSession(
+            referral_id=referral_id,
+            session_date=session_date,
+            status=status
+        )
+        session.add(test_session)
+        session.commit()
+        return test_session.id
+
+# --- Cognitive Score Insert ---
+def insert_cognitive_scores(session_id, scores):
+    def clean(val):
+        if val is None:
+            return None
+        try:
+            return float(val)
+        except Exception:
+            return val
+    with Session() as session:
+        records = [
+            CognitiveScore(
+                session_id=session_id,
+                patient_id=score.get('patient_id'),  # Add patient_id
+                domain=score['domain'],
+                patient_score=clean(score.get('patient_score')),
+                standard_score=clean(score.get('standard_score')),
+                percentile=clean(score.get('percentile')),
+                validity_index=score.get('validity_index'),
+            )
+            for score in scores
+        ]
+        session.add_all(records)
+        session.commit()
+        return len(records)
+
+# --- Subtest Result Insert ---
+def insert_subtest_results(session_id, subtests):
+    with Session() as session:
+        records = [
+            SubtestResult(
+                session_id=session_id,
+                patient_id=s['patient_id'],  # Add patient_id
+                subtest_name=s['subtest_name'],
+                metric=s['metric'],
+                score=s.get('score'),
+                standard_score=s.get('standard_score'),
+                percentile=s.get('percentile'),
+                validity_flag=s.get('validity_flag', True),
+            )
+            for s in subtests
+        ]
+        session.add_all(records)
+        session.commit()
+        return len(records)
+
+# --- ASRS Response Insert ---
+def insert_asrs_responses(session_id, responses):
+    with Session() as session:
+        records = [
+            ASRSResponse(
+                session_id=session_id,
+                patient_id=resp.get('patient_id'),  # Add patient_id
+                question_number=resp['question_number'],
+                part=resp.get('part'),
+                response=resp['response'],
+            )
+            for resp in responses
+        ]
+        session.add_all(records)
+        session.commit()
+        return len(records)
+
+# --- DSM Diagnosis Insert ---
+def insert_dsm_diagnosis(session_id, diagnoses):
+    with Session() as session:
+        records = [
+            DSMDiagnosis(
+                session_id=session_id,
+                patient_id=diag.get('patient_id'),  # Add patient_id
+                diagnosis=diag['diagnosis'],
+                code=diag.get('code'),
+                severity=diag.get('severity'),
+                notes=diag.get('notes'),
+            )
+            for diag in diagnoses
+        ]
+        session.add_all(records)
+        session.commit()
+        return len(records)
+
+# --- Insert DSM Criteria Met ---
+def insert_dsm_criteria_met(session_id, criteria_data):
+    with Session() as session:
+        records = [
+            DSMCriteriaMet(
+                session_id=session_id,
+                patient_id=item.get('patient_id'),  # Add patient_id
+                dsm_criterion=item['dsm_criterion'],
+                dsm_category=item['dsm_category'],
+                is_met=bool(item['is_met']),
+            )
+            for item in criteria_data
+        ]
+        session.add_all(records)
+        session.commit()
+        return len(records)
+
+# --- Insert Epworth Responses ---
+def insert_epworth_responses(session_id, responses):
+    with Session() as session:
+        records = [
+            EpworthResponse(
+                session_id=session_id,
+                patient_id=resp.get('patient_id'),  # Add patient_id
+                situation=resp['situation'],
+                score=resp['score'],
+            )
+            for resp in responses
+        ]
+        session.add_all(records)
+        session.commit()
+        return len(records)
+
+# --- Insert Epworth Summary ---
+def insert_epworth_summary(session_id, summary):
+    with Session() as session:
+        record = EpworthSummary(
+            session_id=session_id,
+            patient_id=summary.get('patient_id'),  # Add patient_id
+            total_score=summary['total_score'],
+            interpretation=summary.get('interpretation'),
+        )
+        session.add(record)
+        session.commit()
+        return 1
+
+# --- Insert NPQ Domain Scores ---
+def insert_npq_domain_scores(session_id, scores):
+    with Session() as session:
+        records = [
+            NPQDomainScore(
+                session_id=session_id,
+                patient_id=score.get('patient_id'),  # Add patient_id
+                domain=score['domain'],
+                score=score['score'],
+                severity=score['severity'],
+            )
+            for score in scores
+        ]
+        session.add_all(records)
+        session.commit()
+        return len(records)
+
+# --- Insert NPQ Responses ---
+def insert_npq_responses(session_id, responses):
+    with Session() as session:
+        records = [
+            NPQResponse(
+                session_id=session_id,
+                patient_id=resp.get('patient_id'),  # Add patient_id
+                domain=resp['domain'],
+                question_number=resp['question_number'],
+                question_text=resp['question_text'],
+                score=resp['score'],
+                severity=resp['severity'],
+            )
+            for resp in responses
+        ]
+        session.add_all(records)
+        session.commit()
+        return len(records)

--- a/src/report_refactor/cognitive_importer.py
+++ b/src/report_refactor/cognitive_importer.py
@@ -1,0 +1,165 @@
+def import_pdf_to_db(pdf_path):
+    """
+    Parses a cognitive report PDF using parsing_helpers and imports the data into the unified SQLAlchemy database.
+    Returns True on success, False on failure.
+    """
+    logger.info(f"Attempting to import PDF data for: {pdf_path}")
+
+    # --- Stage 1: Extract text blocks ---
+    lines = extract_text_blocks(pdf_path)
+    if not lines:
+        logger.error(f"Could not extract any text blocks from {pdf_path}.")
+        return False
+    raw_text = "\n".join(lines)
+    
+    # --- Stage 2: Parse Patient Info ---
+    patient_info_tuple = parse_basic_info(raw_text)
+    if not patient_info_tuple or not patient_info_tuple[0]:
+        logger.error(f"Essential patient information (ID) could not be parsed from {pdf_path}.")
+        return False
+    patient_id, test_date, age, language = patient_info_tuple
+    patient_info = {
+        'patient_id': patient_id,
+        'test_date': test_date,
+        'age': age,
+        'language': language
+    }
+
+    # --- Stage 3: Referral/Session Setup (unchanged) ---
+    referral_id = patient_info.get('referral_id')
+    if not referral_id:
+        from db import Session, Referral
+        with Session() as session:
+            referral = session.query(Referral).filter_by(id_number=patient_info.get('patient_id')).first()
+            if referral:
+                referral_id = referral.id
+            else:
+                from datetime import datetime
+                from db import save_referral
+                referral_id = save_referral(
+                    {'email': patient_info.get('email', ''),
+                     'mobile': patient_info.get('mobile', ''),
+                     'dob': patient_info.get('dob', ''),
+                     'id_number': patient_info.get('patient_id', '')},
+                    subject='[Auto-imported]',
+                    body='',
+                    referrer=None,
+                    referrer_email=None,
+                    referral_received_time=datetime.now(),
+                    referral_confirmed_time=None
+                )
+    session_date = patient_info.get('test_date')
+    from datetime import datetime
+    if isinstance(session_date, str):
+        try:
+            session_date = datetime.strptime(session_date, '%B %d, %Y %H:%M:%S')
+        except Exception:
+            try:
+                session_date = datetime.strptime(session_date, '%Y-%m-%d %H:%M:%S')
+            except Exception:
+                session_date = datetime.now()
+    elif session_date is None:
+        session_date = datetime.now()
+    session_id = create_test_session(referral_id, session_date, status="parsed")
+
+    # --- Stage 4: Parse and Insert Data ---
+    # Cognitive Scores
+    raw_score_tuples = parse_cognitive_scores(raw_text, patient_id)
+    # Convert tuples to dicts, sanitize only numeric fields
+    raw_score_dicts = [
+        {
+            'domain': t[1],
+            'patient_score': safe_float(t[2]),
+            'standard_score': safe_float(t[3]),
+            'percentile': safe_float(t[4]),
+            'validity_index': t[5] if len(t) > 5 else None,
+            'patient_id': patient_id  # <-- Add patient_id to dict
+        }
+        for t in raw_score_tuples
+    ]
+    insert_cognitive_scores(session_id, raw_score_dicts)
+
+    # Epworth
+    epworth_total, epworth_responses = parse_epworth(raw_text, patient_id)
+    # Convert tuples to dicts for DB insert
+    epworth_response_dicts = [
+        {'situation': t[2], 'score': t[3], 'patient_id': patient_id} for t in epworth_responses
+    ]
+    insert_epworth_responses(session_id, epworth_response_dicts)
+    if epworth_total is not None:
+        insert_epworth_summary(session_id, {'total_score': epworth_total, 'patient_id': patient_id})
+
+    # Subtests
+    logger.info(f"Parsing cognitive subtests from PDF: {pdf_path}")
+    subtest_tuples = parse_all_subtests(pdf_path, patient_id)
+    subtest_dicts = [
+        {
+            'subtest_name': t[1],
+            'metric': t[2],
+            'score': t[3],
+            'standard_score': t[4],
+            'percentile': t[5],
+            'validity_flag': t[6] if len(t) > 6 else True,
+            'patient_id': patient_id  # <-- Add patient_id to dict
+        }
+        for t in subtest_tuples
+    ]
+    insert_subtest_results(session_id, subtest_dicts)
+
+    # ASRS
+    asrs_tuples = parse_asrs_with_bounding_boxes(pdf_path, patient_id)
+    asrs_dicts = [
+        {
+            'question_number': t[1],
+            'part': t[2],
+            'response': t[3],
+            'patient_id': patient_id
+        }
+        for t in asrs_tuples
+    ]
+    insert_asrs_responses(session_id, asrs_dicts)
+
+    # NPQ
+    npq_pages = find_npq_pages(pdf_path)
+    npq_questions = []
+    npq_domain_scores = []
+    if npq_pages:
+        npq_questions = extract_npq_questions_pymupdf(pdf_path, npq_pages)
+        npq_questions = [
+            {
+                'question_number': t[0],
+                'question_text': t[1],
+                'score': t[2],
+                'severity': t[3],
+                'domain': t[4] if len(t) > 4 else None,
+                'patient_id': patient_id
+            }
+            for t in npq_questions
+        ]
+        npq_domain_scores = extract_npq_domain_scores_from_pdf(pdf_path, npq_pages)
+        npq_domain_scores = [
+            {
+                'domain': t[0],
+                'score': t[1],
+                'severity': t[2],
+                'patient_id': patient_id
+            }
+            for t in npq_domain_scores
+        ]
+    insert_npq_responses(session_id, npq_questions)
+    insert_npq_domain_scores(session_id, npq_domain_scores)
+
+    # DSM
+    dsm = extract_dsm_diagnosis(asrs_dicts, patient_id)
+    if dsm:
+        for d in dsm:
+            d['patient_id'] = patient_id
+        insert_dsm_diagnosis(session_id, dsm)
+    criteria_data = extract_dsm_criteria(asrs_dicts, patient_id)
+    if criteria_data:
+        for c in criteria_data:
+            c['patient_id'] = patient_id
+        insert_dsm_criteria_met(session_id, criteria_data)
+
+    logger.info(f"Successfully imported all available data for session ID: {session_id}")
+    return True


### PR DESCRIPTION
### Summary
This pull request adds a `patient_id` field to all result tables (CognitiveScore, SubtestResult, ASRSResponse, DSMDiagnosis, DSMCriteriaMet, EpworthResponse, EpworthSummary, NPQDomainScore, NPQResponse) and ensures the patient ID parsed from the PDF is propagated and stored with every result row.

### Details
- Updates database models to include `patient_id`.
- Updates all insert logic to accept and store `patient_id`.
- Updates PDF parsing/import logic to propagate the patient ID to all result insertions.

### Why?
This improves traceability, data integrity, and supports robust downstream analytics and compliance by ensuring every result row is uniquely linked to the patient.

---
Please review and merge if approved. Let me know if you need further changes or testing before merge.