### PR TITLE
Prioritize severe NPQ symptoms before moderate; formatting and whitespace improvements

### DIFF
--- a/src/report_engine/executive_summary.py
+++ b/src/report_engine/executive_summary.py
@@ -1,0 +1,45 @@
+def get_npq_impacted_domains(npq_scores, min_severity_level=2):
+    """Identifies NPQ domains with moderate or higher severity."""
+    # min_severity_level: 1=Mild, 2=Moderate, 3=Severe
+    impacted = []
+    severity_map = {"Not a problem": 0, "A mild problem": 1, "Mild": 1,
+                    "A moderate problem": 2, "Moderate": 2,
+                    "A severe problem": 3, "Severe": 3}
+
+    for score in npq_scores:
+        if score.get('severity') and score['severity'] in severity_map:
+             # Check if severity meets the minimum threshold (default: Moderate)
+            current_severity_level = severity_map[score['severity']]
+            if current_severity_level >= min_severity_level:
+                if "Average" not in score['domain']: # Exclude summary scores
+                     severity_text = score['severity'].replace("A ", "").replace(" problem", "").capitalize()
+                     impacted.append(f"{score['domain']} ({severity_text})")
+
+    impacted.sort()
+    return impacted
+
+def get_severe_npq_symptoms(npq_questions, min_severity_score=2):
+    """Identifies specific NPQ questions rated as moderate or severe (default) and removes duplicates. Severe symptoms are listed first."""
+    severe = []
+    moderate = []
+    seen = set()
+    severity_map = {"Not a problem": 0, "A mild problem": 1, "Mild": 1,
+                    "A moderate problem": 2, "Moderate": 2,
+                    "A severe problem": 3, "Severe": 3}
+
+    for q in npq_questions:
+        if q.get('severity') and q['severity'] in severity_map:
+            if severity_map[q['severity']] >= min_severity_score:
+                severity_text = q['severity'].replace("A ", "").replace(" problem", "").capitalize()
+                symptom_text = f"{q['question_text']} ({severity_text})"
+                if symptom_text not in seen:
+                    if severity_map[q['severity']] == 3:
+                        severe.append(symptom_text)
+                    else:
+                        moderate.append(symptom_text)
+                    seen.add(symptom_text)
+
+    # Severe first, then moderate
+    severe.sort()
+    moderate.sort()
+    return severe + moderate

--- a/templates/report_template_sum_valid.html
+++ b/templates/report_template_sum_valid.html
@@ -1,0 +1,52 @@
+        /* Aggressive whitespace minimization for executive summary */
+        .executive-summary ul,
+        .executive-summary ol {
+            margin: 0 !important;
+            padding-left: 1.1em !important;
+            line-height: 1.25 !important;
+        }
+        .executive-summary li {
+            margin: 0 !important;
+            padding: 0 !important;
+            line-height: 1.25 !important;
+        }
+        .executive-summary .summary-body {
+            margin: 0 !important;
+            padding: 0 !important;
+            line-height: 1.25 !important;
+        }
+        .executive-summary .summary-section {
+            margin: 0 !important;
+            padding: 0 !important;
+        }
+        .executive-summary {
+            padding-top: 0 !important;
+            padding-bottom: 0 !important;
+            margin-top: 0 !important;
+            margin-bottom: 0 !important;
+            line-height: 1.25 !important;
+        }
+        .executive-summary span[style*="font-weight:bold"] {
+            display: block;
+            margin: 0 !important;
+            padding: 0 !important;
+            line-height: 1.25 !important;
+        }
+        .executive-summary div[style*="font-size:12px"] {
+            margin: 0 !important;
+            padding: 0 !important;
+            line-height: 1.25 !important;
+        }
+        /* Custom class for ADHD criteria list */
+        .executive-summary ul.adhd-criteria-list {
+            margin: 0 0 0 1.8em !important;
+            padding-left: 0 !important;
+            list-style-type: none !important;
+        }
+        .executive-summary ul.adhd-criteria-list li {
+            margin: 0 !important;
+            padding: 0 !important;
+            text-indent: -1.2em !important;
+            padding-left: 1.2em !important;
+            line-height: 1.25 !important;
+        }


### PR DESCRIPTION
- get_severe_npq_symptoms now returns 'Severe' symptoms first, then 'Moderate', both sorted alphabetically.
- CSS and template changes align ADHD criteria indentation with cognitive lists.
- Aggressive whitespace minimization and formatting improvements for executive summary.

Closes #3.